### PR TITLE
Fix error with generating save dumps that use numbers as keys

### DIFF
--- a/models/lua_state.py
+++ b/models/lua_state.py
@@ -1,10 +1,11 @@
 import copy
 from io import BytesIO
 from typing import Dict, Any, List
-import json
+from ast import literal_eval
 
 from luabins import decode_luabins, encode_luabins
 import lz4.block
+from pprintpp import pprint
 
 from constant import SAV15_UNCOMPRESSED_SIZE, SAV16_UNCOMPRESSED_SIZE
 
@@ -143,8 +144,8 @@ class LuaState:
 
     def dump_to_file(self, path: str):
         with open(path, 'w') as f:
-            f.write(json.dumps(self._active_state, indent=2))
+            pprint(self._active_state, indent=2, stream=f)
 
     def load_from_file(self, path: str):
         with open(path, 'r') as f:
-            self._active_state = json.loads(f.read())
+            self._active_state = literal_eval(f.read())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ click
 construct
 luabins_py==1.4.0
 PyQt5
+pprintpp
 pyinstaller
 lz4


### PR DESCRIPTION
It seems the problems with the Lua state dump/import were related to how JSON handles/doesn't handle numbers as keys. json.dump() kept converting them to strings which then caused corrupted save files when re-imported.

Also I used the external pprintpp lib because it generates 1000% more readable output than the built-in pprint.